### PR TITLE
feat: simple db cache plugin

### DIFF
--- a/packages/api-server/src/block-emitter.ts
+++ b/packages/api-server/src/block-emitter.ts
@@ -5,8 +5,21 @@ import { EventEmitter } from "events";
 import { toApiNewHead } from "./db/types";
 import cluster from "cluster";
 import * as Sentry from "@sentry/node";
+import { Store } from "./cache/store";
+import {
+  TIP_BLOCK_HASH_CACHE_KEY,
+  TIP_BLOCK_HASH_CACHE_EXPIRED_TIME_MS,
+} from "./cache/constant";
 
 const newrelic = require("newrelic");
+
+// init cache
+const cacheStore: Store = new Store(
+  envConfig.redisUrl,
+  true,
+  TIP_BLOCK_HASH_CACHE_EXPIRED_TIME_MS
+);
+cacheStore.init();
 
 // Only start in main worker, and `startWorker` in workers to get emitter.
 export class BlockEmitter {
@@ -104,12 +117,19 @@ export class BlockEmitter {
       const newHeads = blocks.map((b) => toApiNewHead(b));
       this.notify("newHeads", newHeads);
 
+      // update tipBlockHash in cache
+      cacheStore.insert(
+        TIP_BLOCK_HASH_CACHE_KEY,
+        newHeads[newHeads.length - 1].hash
+      );
+
       const logs = await this.query.getLogsByFilter({
         fromBlock: min + BigInt(1),
         toBlock: max,
         addresses: [],
         topics: [],
       });
+
       const newLogs = logs.map((log) =>
         JSON.stringify(
           log,

--- a/packages/api-server/src/block-emitter.ts
+++ b/packages/api-server/src/block-emitter.ts
@@ -14,12 +14,7 @@ import {
 const newrelic = require("newrelic");
 
 // init cache
-const cacheStore: Store = new Store(
-  envConfig.redisUrl,
-  true,
-  TIP_BLOCK_HASH_CACHE_EXPIRED_TIME_MS
-);
-cacheStore.init();
+const cacheStore: Store = new Store(true, TIP_BLOCK_HASH_CACHE_EXPIRED_TIME_MS);
 
 // Only start in main worker, and `startWorker` in workers to get emitter.
 export class BlockEmitter {

--- a/packages/api-server/src/cache/constant.ts
+++ b/packages/api-server/src/cache/constant.ts
@@ -11,3 +11,9 @@ export const TX_HASH_MAPPING_CACHE_EXPIRED_TIME_MILSECS = 2 * 60 * 60 * 1000; //
 export const AUTO_CREATE_ACCOUNT_PREFIX_KEY = "AutoCreateAccount";
 export const AUTO_CREATE_ACCOUNT_CACHE_EXPIRED_TIME_MILSECS =
   2 * 60 * 60 * 1000; // 2 hours
+
+export const TIP_BLOCK_HASH_CACHE_KEY = "tipBlockHash";
+export const TIP_BLOCK_HASH_CACHE_EXPIRED_TIME_MS = 1000 * 60 * 5; // 5 minutes
+
+// knex db query cache time
+export const QUERY_CACHE_EXPIRED_TIME_MS = 1000 * 45; // 45 seconds ~= block produce interval

--- a/packages/api-server/src/db/knex.ts
+++ b/packages/api-server/src/db/knex.ts
@@ -1,0 +1,321 @@
+import Knex from "knex";
+import { Store } from "../cache/store";
+import { envConfig } from "../base/env-config";
+import { logger } from "../base/logger";
+import {
+  TIP_BLOCK_HASH_CACHE_KEY,
+  QUERY_CACHE_EXPIRED_TIME_MS,
+} from "../cache/constant";
+
+// init cache
+const cacheStore: Store = new Store(
+  envConfig.redisUrl,
+  true,
+  QUERY_CACHE_EXPIRED_TIME_MS
+);
+cacheStore.init();
+
+const MAX_CACHE_SIZE = 100 * 1024; // 100k
+
+declare module "knex" {
+  namespace Knex {
+    interface QueryInterface<TRecord extends {} = any, TResult = any> {
+      cache: Select<TRecord, TResult>;
+    }
+  }
+}
+
+Knex.QueryBuilder.extend("cache", function useCache(this) {
+  return getCacheKey(this).then((cacheKey) => {
+    return cacheStore.get(cacheKey).then((value) => {
+      // use cache
+      if (value != null) {
+        const data = JSON.parse(value);
+        return deserializeData(data);
+      }
+
+      // query from db
+      return this.then((data) => {
+        if (data == null) {
+          return data;
+        }
+
+        // limit cache size
+        const size = Buffer.from(JSON.stringify(data), "utf-8").byteLength;
+        if (size > MAX_CACHE_SIZE) {
+          logger.debug(
+            `Max cache size(${MAX_CACHE_SIZE} bytes) exceed, total ${size} bytes.`
+          );
+          return data;
+        }
+
+        let sData;
+        try {
+          sData == serializeData(data);
+          cacheStore.insert(cacheKey, JSON.stringify(serializeData(data)));
+        } catch (error: any) {
+          logger.error("abort to cache the result, ", error.message);
+        }
+
+        return data;
+      }) as any;
+    }) as any;
+  }) as any;
+});
+
+// cacheKey format:
+//    `${SQL select str}:${tipBlockHash.slice(0,10)}`
+function getCacheKey(builder: any) {
+  const querySql = builder.toSQL();
+  let sql = querySql.sql.toString();
+  const bindings = querySql.toNative().bindings;
+  for (let bind of bindings) {
+    if (bind != null) {
+      const bindStr =
+        bind instanceof Buffer ? bind.toString("hex") : bind.toLocaleString();
+      sql = sql.replace("?", bindStr);
+    }
+  }
+  return Promise.resolve(cacheStore.get(TIP_BLOCK_HASH_CACHE_KEY)).then(
+    (tipBlockHash: string | null) => {
+      const tipHashSlice = tipBlockHash
+        ? tipBlockHash.slice(0, 10)
+        : "0x" + "0".repeat(8);
+      const cacheKey = `${sql}:${tipHashSlice}`;
+      return cacheKey;
+    }
+  );
+}
+
+// support all types from db table field
+function normalizeDataType(data: any): Data {
+  if (data == null) {
+    return {
+      type: DataType.NULLABLE,
+      value: undefined,
+    };
+  }
+
+  if (typeof data === "string") {
+    return {
+      type: DataType.STRING,
+      value: data,
+    };
+  }
+
+  if (typeof data === "number") {
+    return {
+      type: DataType.NUMBER,
+      value: data,
+    };
+  }
+
+  if (typeof data === "bigint") {
+    return {
+      type: DataType.BIGINT,
+      value: data,
+    };
+  }
+
+  if (typeof data === "boolean") {
+    return {
+      type: DataType.BOOLEAN,
+      value: data,
+    };
+  }
+
+  if (data instanceof Date) {
+    return {
+      type: DataType.DATE,
+      value: data,
+    };
+  }
+
+  if (data instanceof Buffer) {
+    return {
+      type: DataType.BUFFER,
+      value: data,
+    };
+  }
+
+  if (Array.isArray(data)) {
+    return {
+      type: DataType.ARRAY,
+      value: data,
+    };
+  }
+
+  if (typeof data === "object") {
+    return {
+      type: DataType.OBJ,
+      value: data,
+    };
+  }
+
+  throw new Error("un supported type" + typeof data);
+}
+
+function serializeData(data: any): SerializableData {
+  const { type, value } = normalizeDataType(data);
+  switch (type) {
+    case DataType.NULLABLE:
+      return {
+        type,
+        value: "undefined",
+      };
+
+    case DataType.STRING:
+      return {
+        type,
+        value: value as string,
+      };
+
+    case DataType.NUMBER:
+      return {
+        type,
+        value: value as number,
+      };
+
+    case DataType.BIGINT: {
+      const data = "0x" + (value as bigint).toString(16);
+      return {
+        type,
+        value: data,
+      };
+    }
+
+    case DataType.BOOLEAN: {
+      const data = (value as boolean).toString();
+      return {
+        type,
+        value: data,
+      };
+    }
+
+    case DataType.BUFFER: {
+      const data = "0x" + (value as Buffer).toString("hex");
+      return {
+        type,
+        value: data,
+      };
+    }
+
+    case DataType.DATE: {
+      const data = (value as Date).toString();
+      return {
+        type,
+        value: data,
+      };
+    }
+
+    case DataType.ARRAY: {
+      let data: SerializableData[] = (value as Array<DataType>).map((v) =>
+        serializeData(v)
+      );
+      return {
+        type,
+        value: data,
+      };
+    }
+
+    case DataType.OBJ: {
+      let data: any = {};
+      for (const k in value as any) {
+        let v = (value as any)[k];
+        data[k] = serializeData(v);
+      }
+      return {
+        type,
+        value: data,
+      };
+    }
+  }
+}
+
+function deserializeData(data: any): DataValue {
+  const { type, value } = data;
+
+  switch (type) {
+    case DataType.NULLABLE:
+      return undefined;
+
+    case DataType.STRING:
+      return value as string;
+
+    case DataType.NUMBER:
+      return +value;
+
+    case DataType.BIGINT: {
+      const data = BigInt(value);
+      return data;
+    }
+
+    case DataType.BOOLEAN: {
+      const data: boolean = JSON.parse(value);
+      return data;
+    }
+
+    case DataType.BUFFER: {
+      const data = Buffer.from(value.slice(2), "hex");
+      return data;
+    }
+
+    case DataType.DATE: {
+      const data = new Date(value);
+      return data;
+    }
+
+    case DataType.ARRAY: {
+      return (value as Array<any>).map((v) => deserializeData(v));
+    }
+
+    case DataType.OBJ: {
+      let data: any = {};
+      for (const k in value) {
+        let v: { type: DataType; value: any } = value[k];
+        data[k] = deserializeData(v);
+      }
+      return data as object;
+    }
+
+    default:
+      throw new Error("unsupported type: " + type);
+  }
+}
+
+interface Data {
+  type: DataType;
+  value: DataValue;
+}
+
+enum DataType {
+  NULLABLE,
+  STRING,
+  NUMBER,
+  BIGINT,
+  BOOLEAN,
+  BUFFER,
+  DATE,
+  ARRAY,
+  OBJ,
+}
+
+type DataValue =
+  | Nullable
+  | string
+  | number
+  | bigint
+  | boolean
+  | Buffer
+  | Date
+  | Array<DataValue>
+  | object;
+
+interface SerializableData {
+  type: DataType;
+  value: SerializableDataValue;
+}
+
+type SerializableDataValue = string | number | Array<SerializableData>;
+
+type Nullable = null | undefined;

--- a/packages/api-server/src/db/knex.ts
+++ b/packages/api-server/src/db/knex.ts
@@ -43,9 +43,8 @@ Knex.QueryBuilder.extend("cache", function useCache(this) {
           return data;
         }
 
-        let sData;
         try {
-          sData == serializeData(data);
+          // call serializeData to allow deserialize later with correct data type restored
           cacheStore.insert(cacheKey, JSON.stringify(serializeData(data)));
         } catch (error: any) {
           logger.error("abort to cache the result, ", error.message);
@@ -85,7 +84,7 @@ function getCacheKey(builder: any) {
 function normalizeDataType(data: any): Data {
   if (data == null) {
     return {
-      type: DataType.NULLABLE,
+      type: DataType.NULL_OR_UNDEFINED,
       value: undefined,
     };
   }
@@ -146,13 +145,13 @@ function normalizeDataType(data: any): Data {
     };
   }
 
-  throw new Error("un supported type" + typeof data);
+  throw new Error(`Unsupported type: ${typeof data}`);
 }
 
 function serializeData(data: any): SerializableData {
   const { type, value } = normalizeDataType(data);
   switch (type) {
-    case DataType.NULLABLE:
+    case DataType.NULL_OR_UNDEFINED:
       return {
         type,
         value: "undefined",
@@ -230,7 +229,7 @@ function deserializeData(data: any): DataValue {
   const { type, value } = data;
 
   switch (type) {
-    case DataType.NULLABLE:
+    case DataType.NULL_OR_UNDEFINED:
       return undefined;
 
     case DataType.STRING:
@@ -273,7 +272,7 @@ function deserializeData(data: any): DataValue {
     }
 
     default:
-      throw new Error("unsupported type: " + type);
+      throw new Error(`Unsupported type: ${type}`);
   }
 }
 
@@ -283,7 +282,7 @@ interface Data {
 }
 
 enum DataType {
-  NULLABLE,
+  NULL_OR_UNDEFINED = 0,
   STRING,
   NUMBER,
   BIGINT,
@@ -295,7 +294,7 @@ enum DataType {
 }
 
 type DataValue =
-  | Nullable
+  | NullOrUndefined
   | string
   | number
   | bigint
@@ -312,4 +311,4 @@ interface SerializableData {
 
 type SerializableDataValue = string | number | Array<SerializableData>;
 
-type Nullable = null | undefined;
+type NullOrUndefined = null | undefined;

--- a/packages/api-server/src/db/knex.ts
+++ b/packages/api-server/src/db/knex.ts
@@ -1,6 +1,5 @@
 import Knex from "knex";
 import { Store } from "../cache/store";
-import { envConfig } from "../base/env-config";
 import { logger } from "../base/logger";
 import {
   TIP_BLOCK_HASH_CACHE_KEY,
@@ -8,12 +7,7 @@ import {
 } from "../cache/constant";
 
 // init cache
-const cacheStore: Store = new Store(
-  envConfig.redisUrl,
-  true,
-  QUERY_CACHE_EXPIRED_TIME_MS
-);
-cacheStore.init();
+const cacheStore: Store = new Store(true, QUERY_CACHE_EXPIRED_TIME_MS);
 
 const MAX_CACHE_SIZE = 100 * 1024; // 100k
 

--- a/packages/api-server/src/db/knex.ts
+++ b/packages/api-server/src/db/knex.ts
@@ -281,16 +281,24 @@ interface Data {
   value: DataValue;
 }
 
+/*
+  Note: 
+    since DataType will be stored in redis db, if one data type needs to be deprecated, 
+    just simply add comment and not using it, do NOT overwrite the original enum value, 
+    otherwise the old data from redis might be in a wrong type.
+
+    when adding new DataType, simply add append it to the tail.
+*/
 enum DataType {
   NULL_OR_UNDEFINED = 0,
-  STRING,
-  NUMBER,
-  BIGINT,
-  BOOLEAN,
-  BUFFER,
-  DATE,
-  ARRAY,
-  OBJ,
+  STRING = 1,
+  NUMBER = 2,
+  BIGINT = 3,
+  BOOLEAN = 4,
+  BUFFER = 5,
+  DATE = 6,
+  ARRAY = 7,
+  OBJ = 8,
 }
 
 type DataValue =

--- a/packages/api-server/src/db/query.ts
+++ b/packages/api-server/src/db/query.ts
@@ -366,7 +366,7 @@ export class Query {
     let selectLogsJoinTransactions = this.knex<DBLog>("transactions")
       .with("logs", selectLogs)
       .select("logs.*", "transactions.eth_tx_hash")
-      .join("logs", { "logs.transaction_hash": "transactions.hash" })
+      .join("logs", { "logs.transaction_hash": "transactions.hash" });
     let logs: DBLog[] = await selectLogsJoinTransactions
       .timeout(MAX_QUERY_TIME_MILSECS, { cancel: true })
       .cache()

--- a/packages/api-server/src/db/query.ts
+++ b/packages/api-server/src/db/query.ts
@@ -8,6 +8,7 @@ import {
   DBTransaction,
   DBLog,
 } from "./types";
+import "./knex";
 import Knex, { knex, Knex as KnexType } from "knex";
 import { envConfig } from "../base/env-config";
 import { LATEST_MEDIAN_GAS_PRICE } from "./constant";
@@ -87,7 +88,8 @@ export class Query {
     const blockData = await this.knex<DBBlock>("blocks")
       .select("number")
       .orderBy("number", "desc")
-      .first();
+      .first()
+      .cache();
 
     return toBigIntOpt(blockData?.number);
   }
@@ -95,7 +97,8 @@ export class Query {
   async getTipBlock(): Promise<Block | undefined> {
     const block = await this.knex<DBBlock>("blocks")
       .orderBy("number", "desc")
-      .first();
+      .first()
+      .cache();
 
     if (!block) {
       return undefined;
@@ -118,8 +121,10 @@ export class Query {
   private async getBlock(
     params: Readonly<Partial<KnexType.MaybeRawRecord<DBBlock>>>
   ): Promise<Block | undefined> {
-    const block = await this.knex<DBBlock>("blocks").where(params).first();
-
+    const block = await this.knex<DBBlock>("blocks")
+      .where(params)
+      .first()
+      .cache();
     if (!block) {
       return undefined;
     }
@@ -137,7 +142,8 @@ export class Query {
     const blocks = await this.knex<DBBlock>("blocks")
       .where("number", ">", minBlockNumber.toString())
       .andWhere("number", "<=", maxBlockNumber.toString())
-      .orderBy("number", "asc");
+      .orderBy("number", "asc")
+      .cache();
     return blocks.map((block) => formatBlock(block));
   }
 
@@ -151,7 +157,8 @@ export class Query {
     }>("blocks")
       .select("hash", "number")
       .where("number", ">", number.toString())
-      .orderBy("number", order);
+      .orderBy("number", order)
+      .cache();
     return arrayOfHashAndNumber.map((hn) => {
       return { hash: bufferToHex(hn.hash), number: BigInt(hn.number) };
     });
@@ -170,9 +177,9 @@ export class Query {
   private async getTransactions(
     params: Readonly<Partial<KnexType.MaybeRawRecord<DBTransaction>>>
   ): Promise<Transaction[]> {
-    const transactions = await this.knex<DBTransaction>("transactions").where(
-      params
-    );
+    const transactions = await this.knex<DBTransaction>("transactions")
+      .where(params)
+      .cache();
 
     return transactions.map((tx) => formatTransaction(tx));
   }
@@ -216,7 +223,8 @@ export class Query {
   ): Promise<Transaction | undefined> {
     const transaction = await this.knex<DBTransaction>("transactions")
       .where(params)
-      .first();
+      .first()
+      .cache();
 
     if (transaction == null) {
       return undefined;
@@ -244,7 +252,8 @@ export class Query {
   ): Promise<Hash[]> {
     const transactionHashes = await this.knex<DBTransaction>("transactions")
       .select("hash")
-      .where(params);
+      .where(params)
+      .cache();
 
     return transactionHashes.map((tx) => bufferToHex(tx.hash));
   }
@@ -268,7 +277,8 @@ export class Query {
   ): Promise<Hash[]> {
     const transactionHashes = await this.knex<DBTransaction>("transactions")
       .select("eth_tx_hash")
-      .where(params);
+      .where(params)
+      .cache();
 
     return transactionHashes.map((tx) => bufferToHex(tx.eth_tx_hash));
   }
@@ -291,7 +301,8 @@ export class Query {
   ): Promise<number> {
     const data = await this.knex<DBTransaction>("transactions")
       .where(params)
-      .count();
+      .count()
+      .cache();
 
     const count: number = +data[0].count;
 
@@ -303,21 +314,27 @@ export class Query {
   ): Promise<[Transaction, Log[]] | undefined> {
     const tx = await this.knex<DBTransaction>("transactions")
       .where({ hash: hexToBuffer(txHash) })
-      .first();
+      .first()
+      .cache();
 
     if (!tx) {
       return undefined;
     }
 
-    const logs = await this.knex<DBLog>("logs").where({
-      transaction_hash: hexToBuffer(txHash),
-    });
+    const logs = await this.knex<DBLog>("logs")
+      .where({
+        transaction_hash: hexToBuffer(txHash),
+      })
+      .cache();
 
     return [formatTransaction(tx), logs.map((log) => formatLog(log))];
   }
 
   async getTipLog() {
-    let log = await this.knex<DBLog>("logs").orderBy("id", "desc").first();
+    let log = await this.knex<DBLog>("logs")
+      .orderBy("id", "desc")
+      .first()
+      .cache();
     if (log != null) {
       return formatLog(log);
     }
@@ -349,9 +366,10 @@ export class Query {
     let selectLogsJoinTransactions = this.knex<DBLog>("transactions")
       .with("logs", selectLogs)
       .select("logs.*", "transactions.eth_tx_hash")
-      .join("logs", { "logs.transaction_hash": "transactions.hash" });
+      .join("logs", { "logs.transaction_hash": "transactions.hash" })
     let logs: DBLog[] = await selectLogsJoinTransactions
       .timeout(MAX_QUERY_TIME_MILSECS, { cancel: true })
+      .cache()
       .catch((knexError: any) => {
         if (knexError instanceof KnexTimeoutError) {
           throw new LimitExceedError(`query timeout exceeded`);


### PR DESCRIPTION
- machine: apple m1 8c 16g
- start web3: `yarn build && PG_POOL_MAX=10 LOG_LEVEL=error yarn start:prod`
- autocannon rpc bench: https://github.com/RetricSu/rpc-bench `yarn && yarn start`

main [7da1981](https://github.com/nervosnetwork/godwoken-web3/commit/7da198190f271cd174864ee031a2907c1d08b2be)

```sh
eth_blockNumber => TPS: 3617.59 (+361659.00%), Latency: 275.56ms (+27456.00%)
eth_getBlockByNumber => TPS: 1364.34 (+136334.00%), Latency: 725.93ms (+72493.00%)
eth_getTransactionReceipt => TPS: 1015.55 (+101455.00%), Latency: 970.59ms (+96959.00%)
eth_getLogs => TPS: 1039.96 (+103896.00%), Latency: 948.93ms (+94793.00%)
```
cache branch:

```sh
eth_blockNumber => TPS: 8354.35 (+130.94%), Latency: 120.10ms (-56.42%)
eth_getBlockByNumber => TPS: 5392.64 (+295.26%), Latency: 185.56ms (-74.44%)
eth_getTransactionReceipt => TPS: 2545.15 (+150.62%), Latency: 391.61ms (-59.65%)
eth_getLogs => TPS: 1676.83 (+61.24%), Latency: 593.05ms (-37.50%)
```

- upside: simple code, generalize to all DB queries, use cache only explicitly in business logic
- downside: might consume more memory in Redis

should run on some online environment to observe the effect and memory usage