### PR TITLE
fix(call): poly args data byte length

### DIFF
--- a/packages/api-server/src/convert-tx.ts
+++ b/packages/api-server/src/convert-tx.ts
@@ -140,9 +140,9 @@ export function buildPolyjuiceArgs(
   valueBuf.writeBigUInt64LE(value >> BigInt(64), 8);
   const dataSizeBuf = Buffer.alloc(4);
   const dataBuf = Buffer.from(data.slice(2), "hex");
-  dataSizeBuf.writeUInt32LE(dataBuf.length);
+  dataSizeBuf.writeUInt32LE(dataBuf.byteLength);
 
-  let argsLength: number = 8 + 8 + 16 + 16 + 4 + dataBuf.length;
+  let argsLength: number = 8 + 8 + 16 + 16 + 4 + dataBuf.byteLength;
   if (toAddressWhenNativeTransfer != null) {
     argsLength += 20;
   }
@@ -160,7 +160,7 @@ export function buildPolyjuiceArgs(
       toAddressWhenNativeTransfer.slice(2),
       "hex"
     );
-    toAddressBuf.copy(argsBuf, 52 + (data.length - 2));
+    toAddressBuf.copy(argsBuf, 52 + dataBuf.byteLength);
   }
 
   const argsHex = "0x" + argsBuf.toString("hex");
@@ -449,6 +449,7 @@ export async function polyTxToGwTx(
   }
 
   // header
+  // todo: refactor with func buildPolyjuiceArgs
   const args_0_7 =
     "0x" +
     Buffer.from("FFFFFF", "hex").toString("hex") +

--- a/packages/api-server/src/convert-tx.ts
+++ b/packages/api-server/src/convert-tx.ts
@@ -112,6 +112,7 @@ export async function ethCallTxToGodwokenRawTx(
   return [rawL2Transaction, serializedRegistryAddress];
 }
 
+// todo: add unit test for this function
 export function buildPolyjuiceArgs(
   isCreate: boolean,
   gas: bigint,


### PR DESCRIPTION
this bug was introduced by this [commit](https://github.com/godwokenrises/godwoken-web3/commit/2c076adebeb87c01b3e53676bda6437360eba3f3#diff-cce75f92de0f01f77430b0195c78d8a547ca11f2b8f818202008dce92a69ebefR1378) which will cause calling raw tx to transfer native token with non-empty `tx.data` filed to the wrong address and create a new account in polyjuice. Since it is call only, it will not have actual effect on-chain.