### PR TITLE
fix: r & s should be quantity in transaction when `eth_getTransaction…

### DIFF
--- a/packages/api-server/src/base/types/api.ts
+++ b/packages/api-server/src/base/types/api.ts
@@ -14,8 +14,8 @@ export interface EthTransaction {
   nonce: HexNumber;
   value: HexNumber;
   v: HexNumber;
-  r: HexString;
-  s: HexString;
+  r: HexNumber;
+  s: HexNumber;
 }
 
 export interface EthBlock {

--- a/packages/api-server/src/convert-tx.ts
+++ b/packages/api-server/src/convert-tx.ts
@@ -210,8 +210,8 @@ export function polyjuiceRawTransactionToApiTransaction(
     nonce: tx.nonce === "0x" ? "0x0" : tx.nonce,
     value: tx.value === "0x" ? "0x0" : tx.value,
     v: +tx.v % 2 === 0 ? "0x1" : "0x0",
-    r: tx.r,
-    s: tx.s,
+    r: "0x" + BigInt(tx.r).toString(16),
+    s: "0x" + BigInt(tx.s).toString(16),
   };
 }
 

--- a/packages/api-server/src/db/types.ts
+++ b/packages/api-server/src/db/types.ts
@@ -165,8 +165,8 @@ export function toApiTransaction(t: Transaction): EthTransaction {
     nonce: new Uint64(t.nonce || 0n).toHex(), // TODO: check default value
     value: new Uint256(t.value).toHex(),
     v: new Uint64(t.v).toHex(),
-    r: t.r,
-    s: t.s,
+    r: "0x" + BigInt(t.r).toString(16),
+    s: "0x" + BigInt(t.s).toString(16),
   };
 }
 

--- a/packages/api-server/src/filter-web3-tx.ts
+++ b/packages/api-server/src/filter-web3-tx.ts
@@ -77,9 +77,13 @@ export async function filterWeb3Transaction(
 
   const signature: HexString = l2Tx.signature;
   // 0..32 bytes
-  const r = "0x" + signature.slice(2, 66);
+  let r = "0x" + signature.slice(2, 66);
+  // Remove r left zeros
+  r = "0x" + BigInt(r).toString(16);
   // 32..64 bytes
-  const s = "0x" + signature.slice(66, 130);
+  let s = "0x" + signature.slice(66, 130);
+  // Remove s left zeros
+  s = "0x" + BigInt(s).toString(16);
   // signature[65] byte
   const v = Uint32.fromHex("0x" + signature.slice(130, 132));
 


### PR DESCRIPTION
…ByHash`

Related Issues:
- https://github.com/godwokenrises/godwoken/issues/818

`r` and `s` in transaction when call `eth_getTransactionByHash` / `eth_getBlockByNumber(num, true)` / `eth_getBlockByHash(hash, true)` should regard as quantity type.

For example:

```json
{
    "jsonrpc": "2.0",
    "id": 2,
    "result": {
        "blockHash": "0xc88634c7958b9ef61eedd675680ccc9ceff74c97d05696f5565e15be78bb3e1e",
        "blockNumber": "0xf16d75",
        "from": "0x18228ef922a5999a124035160728d68658732995",
        "gas": "0xce53",
        "gasPrice": "0x55ae82600",
        "hash": "0x129851fcb7f03b1e006ae5935f671d927d97617dcefb182a53d775ea61be4ab5",
        "input": "0xa9059cbb000000000000000000000000145a67769bad2fdae1ed2b5dc8c1b6a76f4d9ff2000000000000000000000000000000000000000000000001611fd470a8cca000",
        "nonce": "0x1670",
        "r": "0xbca226c0ffd4ce56d06b6eb4022e11a294e78529fd4f5d29b707df4d566e7ba",
        "s": "0x4926704a019f312d9d765a095eee58e868d855b815b659c00f524be815d288f0",
        "to": "0x1bbf25e71ec48b84d773809b4ba55b6f4be946fb",
        "transactionIndex": "0xf",
        "type": "0x0",
        "v": "0x1c",
        "value": "0x0"
    }
}
```

It's a transaction in ethereum mainnet, the `r` of transaction's length without `0x` prefix is 63, not 64