### PR TITLE
refactor: instant-finality feature via special RPC url

### DIFF
--- a/.github/workflows/godwoken-tests.yml
+++ b/.github/workflows/godwoken-tests.yml
@@ -13,8 +13,6 @@ jobs:
     uses: godwokenrises/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
     with:
       extra_github_env: |
-        GODWOKEN_TESTS_REPO=RetricSu/godwoken-tests
-        GODWOKEN_TESTS_REF=sisyhusGamble-block
         MANUAL_BUILD_WEB3=true
         MANUAL_BUILD_WEB3_INDEXER=true
         WEB3_GIT_URL=https://github.com/${{ github.repository }}

--- a/.github/workflows/godwoken-tests.yml
+++ b/.github/workflows/godwoken-tests.yml
@@ -13,6 +13,8 @@ jobs:
     uses: godwokenrises/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
     with:
       extra_github_env: |
+        GODWOKEN_TESTS_REPO=RetricSu/godwoken-tests
+        GODWOKEN_TESTS_REF=sisyhusGamble-block
         MANUAL_BUILD_WEB3=true
         MANUAL_BUILD_WEB3_INDEXER=true
         WEB3_GIT_URL=https://github.com/${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Web3 RPC compatible layer build upon Godwoken/Polyjuice.
 
+Checkout [additional feature](docs/addtional-feature.md).
+
 ## Development
 
 ### Config database
@@ -121,9 +123,26 @@ docker exec -it <CONTAINER NAME> /bin/bash
 $ root@ec562fe2172b:/godwoken-web3# pm2 monit
 ```
 
-Http url: http://your-url/
+#### URLs
 
-WebSocket url: ws://your-url/ws
+```sh
+# Http 
+http://example_web3_rpc_url
+
+# WebSocket
+ws://example_web3_rpc_url/ws
+```
+
+With instant-finality feature turn on:
+
+```sh
+# Http 
+http://example_web3_rpc_url?instant-finality-hack=true
+http://example_web3_rpc_url/instant-finality-hack
+
+# WebSocket
+ws://example_web3_rpc_url/ws?instant-finality-hack=true
+```
 
 ### Docker Prebuilds
 

--- a/docs/addtional-feature.md
+++ b/docs/addtional-feature.md
@@ -1,0 +1,22 @@
+# Additional Feature
+
+## Instant Finality
+
+Ethereum require a transaction to be on-chain(meaning the transaction is included in the latest block) before returning a final status(aka. transaction receipt) to users so they can know whether the transaction is success or not. 
+
+Godwoken provide a quicker way to confirm transaction. Once the transaction is validated in mempool, users can get instant transaction receipt. This feature is called Instant Finality.
+
+If your want to build a low latency user experience for on-chain interaction in your dapp, you can turn on such feature by using the RPC with additional path or query parameter:
+
+```sh
+# http
+https://example_web3_rpc_url?instant-finality-hack=true
+https://example_web3_rpc_url/instant-finality-hack
+
+# websocket
+ws://example_web3_rpc_url/ws?instant-finality-hack=true
+```
+
+Environment like [Hardhat](https://github.com/NomicFoundation/hardhat) will swallow the http url's query parameter, so you might want to use the `/instant-finality-hack` path to overcome that.
+
+Also notice that under such mode, there might have some [compatibility issue](https://github.com/godwokenrises/godwoken-web3/issues/283) with Ethereum toolchain like `ether.js`. If you care more about the compatibility, please use the bare RPC url `https://example_web3_rpc_url`, which is consider to be most compatible with Ethereum.

--- a/packages/api-server/src/methods/index.ts
+++ b/packages/api-server/src/methods/index.ts
@@ -75,4 +75,9 @@ function getMethods(argsList: ModConstructorArgs = {}) {
   return methods;
 }
 
+const instantFinalityHackMode = true;
+
 export const methods = getMethods();
+export const instantFinalityHackMethods = getMethods({
+  eth: [instantFinalityHackMode],
+});

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -94,16 +94,18 @@ type GodwokenBlockParameter = U64 | undefined;
 export class Eth {
   private query: Query;
   private rpc: GodwokenClient;
+  private instantFinalityHackMode: boolean;
   private filterManager: FilterManager;
   private cacheStore: Store;
   private ethNormalizer: EthNormalizer;
 
-  constructor() {
+  constructor(instantFinalityHackMode: boolean = false) {
     this.query = new Query();
     this.rpc = new GodwokenClient(
       envConfig.godwokenJsonRpc,
       envConfig.godwokenReadonlyJsonRpc
     );
+    this.instantFinalityHackMode = instantFinalityHackMode;
     this.filterManager = new FilterManager(true);
     this.cacheStore = new Store(true, CACHE_EXPIRED_TIME_MILSECS);
     this.ethNormalizer = new EthNormalizer(this.rpc);
@@ -718,86 +720,94 @@ export class Eth {
 
   async getTransactionByHash(args: [string]): Promise<EthTransaction | null> {
     const ethTxHash: Hash = args[0];
-    const cacheKey = autoCreateAccountCacheKey(ethTxHash);
+    const acaCacheKey = autoCreateAccountCacheKey(ethTxHash);
 
     // 1. Find in db
     const tx = await this.query.getTransactionByEthTxHash(ethTxHash);
     if (tx != null) {
       // no need await
       // delete auto create account tx if already in db
-      this.cacheStore.delete(cacheKey);
+      this.cacheStore.delete(acaCacheKey);
       const apiTx = toApiTransaction(tx);
       return apiTx;
     }
 
-    // 2. If null, find pending transactions
-    const ethTxHashKey = ethTxHashCacheKey(ethTxHash);
-    const gwTxHash: Hash | null = await this.cacheStore.get(ethTxHashKey);
-    if (gwTxHash != null) {
-      const godwokenTxWithStatus = await this.rpc.getTransaction(gwTxHash);
-      if (godwokenTxWithStatus == null) {
-        return null;
-      }
-      const godwokenTxReceipt = await this.rpc.getTransactionReceipt(gwTxHash);
-      const tipBlock = await this.query.getTipBlock();
-      if (tipBlock == null) {
-        throw new Error("tip block not found!");
-      }
-      let ethTxInfo = undefined;
-      try {
-        ethTxInfo = await filterWeb3Transaction(
-          ethTxHash,
-          this.rpc,
-          tipBlock.number,
-          tipBlock.hash,
-          godwokenTxWithStatus.transaction,
-          godwokenTxReceipt
+    // 2. If under instant-finality hack mode, find tx from gw mempool block
+    if (this.instantFinalityHackMode) {
+      logger.debug(
+        `[eth_getTransactionByHash] find with instant-finality hack`
+      );
+      // A. find pending transactions
+      const ethTxHashKey = ethTxHashCacheKey(ethTxHash);
+      const gwTxHash: Hash | null = await this.cacheStore.get(ethTxHashKey);
+      if (gwTxHash != null) {
+        const godwokenTxWithStatus = await this.rpc.getTransaction(gwTxHash);
+        if (godwokenTxWithStatus == null) {
+          return null;
+        }
+        const godwokenTxReceipt = await this.rpc.getTransactionReceipt(
+          gwTxHash
         );
-      } catch (err) {
-        logger.error("filterWeb3Transaction:", err);
-        logger.info("godwoken tx:", godwokenTxWithStatus);
-        logger.info("godwoken receipt:", godwokenTxReceipt);
-        throw err;
-      }
-      if (ethTxInfo != null) {
-        const ethTx = ethTxInfo[0];
-        return ethTx;
-      }
-    }
-
-    // 3. Find by auto create account tx
-    // TODO: delete cache store if dropped by godwoken
-    // convert to tx hash mapping store if account id generated ?
-    const polyjuiceRawTx = await this.cacheStore.get(cacheKey);
-    if (polyjuiceRawTx != null) {
-      const tipBlock = await this.query.getTipBlock();
-      if (tipBlock == null) {
-        throw new Error("tip block not found!");
-      }
-      // Convert polyjuice tx to api transaction
-      const { tx, fromAddress }: AutoCreateAccountCacheValue =
-        JSON.parse(polyjuiceRawTx);
-      const isAcaTxExist: boolean = await this.isAcaTxExist(
-        ethTxHash,
-        tx,
-        fromAddress
-      );
-      logger.info(
-        `aca tx: action: getTransactionByHash, eth_tx_hash: ${ethTxHash}, is_tx_exist: ${isAcaTxExist}`
-      );
-      if (isAcaTxExist) {
-        const apiTransaction: EthTransaction =
-          polyjuiceRawTransactionToApiTransaction(
-            tx,
+        const tipBlock = await this.query.getTipBlock();
+        if (tipBlock == null) {
+          throw new Error("tip block not found!");
+        }
+        let ethTxInfo = undefined;
+        try {
+          ethTxInfo = await filterWeb3Transaction(
             ethTxHash,
-            tipBlock.hash,
+            this.rpc,
             tipBlock.number,
-            fromAddress
+            tipBlock.hash,
+            godwokenTxWithStatus.transaction,
+            godwokenTxReceipt
           );
-        return apiTransaction;
-      } else {
-        // If not found, means dropped by godwoken, should delete cache
-        this.cacheStore.delete(cacheKey);
+        } catch (err) {
+          logger.error("filterWeb3Transaction:", err);
+          logger.info("godwoken tx:", godwokenTxWithStatus);
+          logger.info("godwoken receipt:", godwokenTxReceipt);
+          throw err;
+        }
+        if (ethTxInfo != null) {
+          const ethTx = ethTxInfo[0];
+          return ethTx;
+        }
+      }
+
+      // B. Find by auto create account tx
+      // TODO: delete cache store if dropped by godwoken
+      // convert to tx hash mapping store if account id generated ?
+      const polyjuiceRawTx = await this.cacheStore.get(acaCacheKey);
+      if (polyjuiceRawTx != null) {
+        const tipBlock = await this.query.getTipBlock();
+        if (tipBlock == null) {
+          throw new Error("tip block not found!");
+        }
+        // Convert polyjuice tx to api transaction
+        const { tx, fromAddress }: AutoCreateAccountCacheValue =
+          JSON.parse(polyjuiceRawTx);
+        const isAcaTxExist: boolean = await this.isAcaTxExist(
+          ethTxHash,
+          tx,
+          fromAddress
+        );
+        logger.info(
+          `aca tx: action: getTransactionByHash, eth_tx_hash: ${ethTxHash}, is_tx_exist: ${isAcaTxExist}`
+        );
+        if (isAcaTxExist) {
+          const apiTransaction: EthTransaction =
+            polyjuiceRawTransactionToApiTransaction(
+              tx,
+              ethTxHash,
+              tipBlock.hash,
+              tipBlock.number,
+              fromAddress
+            );
+          return apiTransaction;
+        } else {
+          // If not found, means dropped by godwoken, should delete cache
+          this.cacheStore.delete(acaCacheKey);
+        }
       }
     }
 
@@ -861,6 +871,7 @@ export class Eth {
       return null;
     }
 
+    // 1. Find in db
     const data = await this.query.getTransactionAndLogsByHash(gwTxHash);
     if (data != null) {
       const [tx, logs] = data;
@@ -869,37 +880,43 @@ export class Eth {
       return transactionReceipt;
     }
 
-    const godwokenTxWithStatus = await this.rpc.getTransaction(gwTxHash);
-    if (godwokenTxWithStatus == null) {
-      return null;
-    }
-    const godwokenTxReceipt = await this.rpc.getTransactionReceipt(gwTxHash);
-    if (godwokenTxReceipt == null) {
-      return null;
-    }
-    const tipBlock = await this.query.getTipBlock();
-    if (tipBlock == null) {
-      throw new Error(`tip block not found`);
-    }
-    let ethTxInfo = undefined;
-    try {
-      ethTxInfo = await filterWeb3Transaction(
-        ethTxHash,
-        this.rpc,
-        tipBlock.number,
-        tipBlock.hash,
-        godwokenTxWithStatus.transaction,
-        godwokenTxReceipt
+    // 2. If under instant-finality hack mode, build receipt from gw mempool block
+    if (this.instantFinalityHackMode) {
+      logger.debug(
+        `[eth_getTransactionReceipt] find with instant-finality hack`
       );
-    } catch (err) {
-      logger.error("filterWeb3Transaction:", err);
-      logger.info("godwoken tx:", godwokenTxWithStatus);
-      logger.info("godwoken receipt:", godwokenTxReceipt);
-      throw err;
-    }
-    if (ethTxInfo != null) {
-      const ethTxReceipt = ethTxInfo[1]!;
-      return ethTxReceipt;
+      const godwokenTxWithStatus = await this.rpc.getTransaction(gwTxHash);
+      if (godwokenTxWithStatus == null) {
+        return null;
+      }
+      const godwokenTxReceipt = await this.rpc.getTransactionReceipt(gwTxHash);
+      if (godwokenTxReceipt == null) {
+        return null;
+      }
+      const tipBlock = await this.query.getTipBlock();
+      if (tipBlock == null) {
+        throw new Error(`tip block not found`);
+      }
+      let ethTxInfo = undefined;
+      try {
+        ethTxInfo = await filterWeb3Transaction(
+          ethTxHash,
+          this.rpc,
+          tipBlock.number,
+          tipBlock.hash,
+          godwokenTxWithStatus.transaction,
+          godwokenTxReceipt
+        );
+      } catch (err) {
+        logger.error("filterWeb3Transaction:", err);
+        logger.info("godwoken tx:", godwokenTxWithStatus);
+        logger.info("godwoken receipt:", godwokenTxReceipt);
+        throw err;
+      }
+      if (ethTxInfo != null) {
+        const ethTxReceipt = ethTxInfo[1]!;
+        return ethTxReceipt;
+      }
     }
 
     return null;

--- a/packages/api-server/src/middlewares/jayson.ts
+++ b/packages/api-server/src/middlewares/jayson.ts
@@ -1,9 +1,11 @@
 import jayson from "jayson";
-import { methods } from "../methods/index";
+import { instantFinalityHackMethods, methods } from "../methods/index";
 import { Request, Response, NextFunction } from "express";
 import createServer from "connect";
+import { isInstantFinalityHackMode } from "../util";
 
 const server = new jayson.Server(methods);
+const instantFinalityHackServer = new jayson.Server(instantFinalityHackMethods);
 
 export const jaysonMiddleware = (
   req: Request,
@@ -14,6 +16,13 @@ export const jaysonMiddleware = (
   // because this line of code https://github.com/tedeh/jayson/blob/master/lib/utils.js#L331
   if (req.body && req.body.params == null) {
     req.body.params = [] as any[];
+  }
+
+  // enable additional feature for special URL
+  if (isInstantFinalityHackMode(req)) {
+    const middleware =
+      instantFinalityHackServer.middleware() as createServer.NextHandleFunction;
+    return middleware(req, res, next);
   }
 
   const middleware = server.middleware() as createServer.NextHandleFunction;

--- a/packages/api-server/src/util.ts
+++ b/packages/api-server/src/util.ts
@@ -1,4 +1,5 @@
 import { HexString } from "@ckb-lumos/base";
+import { Request } from "express";
 import {
   TX_DATA_NONE_ZERO_GAS,
   TX_DATA_ZERO_GAS,
@@ -119,6 +120,14 @@ export function calcIntrinsicGas(
 export function calcFee(serializedL2Tx: HexString, feeRate: bigint) {
   const byteLen = BigInt(serializedL2Tx.slice(2).length / 2);
   return byteLen * feeRate;
+}
+
+// WEB3_RPC_URL/instant-finality-hack or WEB3_RPC_URL?instant-finality-hack=true
+export function isInstantFinalityHackMode(req: Request): boolean {
+  return (
+    req.url == "/instant-finality-hack" ||
+    (req.query && req.query["instant-finality-hack"] == "true")
+  );
 }
 
 export async function asyncSleep(ms = 0) {


### PR DESCRIPTION
RPC method updated in this PR:
- `eth_getTransactionReceipt`
- RPC which support block parameter, except for
    - `eth_getBlockByNumber`
    - `eth_getBlockTransactionCountByNumber`
    - `eth_getTransactionByBlockNumberAndIndex`
    which does not support pending in our code since a long time ago, we might need to check those 3 RPC methods later

In this pr, we use different RPC URLs to tell if the instant-finality-hack mode is enabled so that we can provide the feature for user while keeping other users who care more about compatibility than such feature happy as well.

Notice how the integration tests last longer in non-instant-finality mode, this can be reduced after we finished the following todos: 
---

TODO before PR merge:

- [ ] update godwoken-tests to use `localhost:8024/instant-finality-hack` mode
    - https://github.com/godwokenrises/godwoken-tests/pull/201
   
One test case is also altered to allow CI to pass under non-instant-finality mode.
- [x] https://github.com/godwokenrises/godwoken-tests/pull/200