### PR TITLE
fix: Return 0x when eth_getCode with zero address

### DIFF
--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -421,6 +421,11 @@ export class Eth {
 
       const address = args[0];
       const blockParameter = args[1];
+
+      if (address === ZERO_ETH_ADDRESS) {
+        return defaultResult;
+      }
+
       const blockNumber: GodwokenBlockParameter =
         await this.parseBlockParameter(blockParameter);
       const accountId: number | undefined = await ethAddressToAccountId(


### PR DESCRIPTION
Related:
- https://github.com/godwokenrises/godwoken-web3/issues/569

Return `0x` when `eth_getCode`'s first parameter equals zero address