### PR TITLE
chore: rm tip block cache to improve ci speed

### DIFF
--- a/packages/api-server/src/db/query.ts
+++ b/packages/api-server/src/db/query.ts
@@ -88,8 +88,7 @@ export class Query {
     const blockData = await this.knex<DBBlock>("blocks")
       .select("number")
       .orderBy("number", "desc")
-      .first()
-      .cache();
+      .first();
 
     return toBigIntOpt(blockData?.number);
   }
@@ -97,8 +96,7 @@ export class Query {
   async getTipBlock(): Promise<Block | undefined> {
     const block = await this.knex<DBBlock>("blocks")
       .orderBy("number", "desc")
-      .first()
-      .cache();
+      .first();
 
     if (!block) {
       return undefined;


### PR DESCRIPTION
This PR rm tip block db query cache to reduce the integration test time from 15m to 4m - https://github.com/godwokenrises/godwoken-web3/actions/runs/3515284891/jobs/5890349513

---
ideally, we should observe the requests to decide whether to use cache for specific db query selections or not. This can be done later in our online environment.